### PR TITLE
set SHELL before running flock with command launch_campaign

### DIFF
--- a/tools/captain/run.sh
+++ b/tools/captain/run.sh
@@ -135,7 +135,7 @@ start_campaign()
                 get_next_cid "$CAMPAIGN_ARDIR")
 
         errno_lock=69
-        flock -xnF -E $errno_lock "${CAMPAIGN_CACHEDIR}/${CACHECID}" \
+        SHELL=/bin/bash flock -xnF -E $errno_lock "${CAMPAIGN_CACHEDIR}/${CACHECID}" \
             flock -xnF -E $errno_lock "${CAMPAIGN_ARDIR}/${ARCID}" \
                 -c launch_campaign || \
         if [ $? -eq $errno_lock ]; then


### PR DESCRIPTION
This should fix #18.

Somehow flock reads the SHELL variable before it starts the command (-c option).
That's why with zsh and fish, the run.sh script fails.