### PR TITLE
Update LLVM_CONFIG

### DIFF
--- a/fuzzers/aflplusplus_lto/build.sh
+++ b/fuzzers/aflplusplus_lto/build.sh
@@ -17,6 +17,7 @@ export CXX=clang++
 export AFL_NO_X86=1
 export PYTHON_INCLUDE=/
 make -j$(nproc) || exit 1
+export "LLVM_CONFIG=/usr/bin/llvm-config-11"
 make -C llvm_mode -j$(nproc) || exit 1
 make -C examples/aflpp_driver || exit 1
 


### PR DESCRIPTION
Update LLVM_CONFIG to be sure that LTO will be build with llvm-11, so prevent conflict with other llvm versions.