### PR TITLE
Fixed missing #ifdef in AAH051.patch

### DIFF
--- a/targets/poppler/patches/bugs/AAH051.patch
+++ b/targets/poppler/patches/bugs/AAH051.patch
@@ -1,8 +1,8 @@
 diff --git a/poppler/Parser.cc b/poppler/Parser.cc
-index 0cb1f7f..d273504 100644
+index 04721005..2db4c6ee 100644
 --- a/poppler/Parser.cc
 +++ b/poppler/Parser.cc
-@@ -283,9 +283,14 @@ Stream *Parser::makeStream(Object &&dict, unsigned char *fileKey,
+@@ -283,8 +283,15 @@ Stream *Parser::makeStream(Object &&dict, const unsigned char *fileKey,
        // When building the xref we can't use it so use this
        // kludge for broken PDF files: just add 5k to the length, and
        // hope its enough
@@ -10,10 +10,11 @@ index 0cb1f7f..d273504 100644
        if (length < LLONG_MAX - pos - 5000)
          length += 5000;
 +#else
++#ifdef MAGMA_ENABLE_CANARIES
 +      MAGMA_LOG("AAH051", length >= LLONG_MAX - pos - 5000);
++#endif
 +      length += 5000;
 +#endif
      }
    }
  
-   // make base stream


### PR DESCRIPTION
Hi, I added a missing `#ifdef MAGMA_ENABLE_CANARIES` to the patch file `AAH051.patch`. Stephan