### PR TITLE
libtiff: use system dependencies

### DIFF
--- a/targets/libtiff/build.sh
+++ b/targets/libtiff/build.sh
@@ -18,35 +18,6 @@ rm -rf "$WORK"
 mkdir -p "$WORK"
 mkdir -p "$WORK/lib" "$WORK/include"
 
-# build zlib
-pushd "$TARGET/zlib"
-./configure --static --prefix="$WORK"
-make -j$(nproc) clean
-make -j$(nproc) CFLAGS="$CFLAGS -fPIC"
-make install
-popd
-
-# Build libjpeg-turbo
-pushd "$TARGET/libjpeg-turbo"
-EXTRA=""
-test -n "$AR" && EXTRA="$EXTRA -DCMAKE_AR=$AR"
-test -n "$RANLIB" && EXTRA="$EXTRA -DCMAKE_RANLIB=$RANLIB"
-cmake . -DCMAKE_INSTALL_PREFIX=$WORK -DENABLE_STATIC=on -DENABLE_SHARED=off $EXTRA
-make -j$(nproc) clean
-make -j$(nproc)
-make install
-EXTRA=""
-popd
-
-# Build libjbig
-pushd "$TARGET/jbigkit"
-make clean
-make lib
-
-cp "$TARGET"/jbigkit/libjbig/*.a "$WORK/lib/"
-cp "$TARGET"/jbigkit/libjbig/*.h "$WORK/include/"
-popd
-
 cd "$TARGET/repo"
 ./autogen.sh
 ./configure --disable-shared --prefix="$WORK"
@@ -57,6 +28,5 @@ make install
 cp "$WORK/bin/tiffcp" "$OUT/"
 $CXX $CXXFLAGS -std=c++11 -I$WORK/include \
     contrib/oss-fuzz/tiff_read_rgba_fuzzer.cc -o $OUT/tiff_read_rgba_fuzzer \
-    $WORK/lib/libtiffxx.a $WORK/lib/libtiff.a $WORK/lib/libz.a $WORK/lib/libjpeg.a \
-    $WORK/lib/libjbig.a $WORK/lib/libjbig85.a -Wl,-Bstatic -llzma -Wl,-Bdynamic \
+    $WORK/lib/libtiffxx.a $WORK/lib/libtiff.a -lz -ljpeg -Wl,-Bstatic -llzma -Wl,-Bdynamic \
     $LDFLAGS $LIBS

--- a/targets/libtiff/fetch.sh
+++ b/targets/libtiff/fetch.sh
@@ -9,18 +9,6 @@ git clone --no-checkout https://gitlab.com/libtiff/libtiff \
     "$TARGET/repo"
 git -C "$TARGET/repo" checkout 1373f8dacb47d0e256889172c6a5a6dc606f00ba
 
-git clone --no-checkout https://github.com/madler/zlib \
-    "$TARGET/zlib"
-git -C "$TARGET/zlib" checkout cacf7f1d4e3d44d871b605da3b647f07d718623f
-
-git clone --no-checkout https://github.com/libjpeg-turbo/libjpeg-turbo \
-    "$TARGET/libjpeg-turbo"
-git -C "$TARGET/libjpeg-turbo" checkout b443c541b9a6fdcac214f9f003de0aa13e480ac1
-
-git clone --no-checkout https://www.cl.cam.ac.uk/~mgk25/git/jbigkit \
-    "$TARGET/jbigkit"
-git -C "$TARGET/jbigkit" checkout dce101373d87445ed55a385fddad02d8a8751de4
-
 # Uncomment default CC and CFLAGS from the build of jbigkit
 patch -p1 -d "$TARGET/jbigkit" << EOF
 --- a/Makefile

--- a/targets/libtiff/preinstall.sh
+++ b/targets/libtiff/preinstall.sh
@@ -2,4 +2,4 @@
 
 apt-get update && \
     apt-get install -y git make autoconf automake libtool cmake nasm \
-        zlib1g-dev liblzma-dev
+        zlib1g-dev liblzma-dev libjpeg-turbo8-dev


### PR DESCRIPTION
This ensures that libtiff is consistent with the other targets.