### PR TITLE
Build sqlite3 with rtree enabled

### DIFF
--- a/targets/sqlite3/build.sh
+++ b/targets/sqlite3/build.sh
@@ -28,7 +28,7 @@ export CFLAGS="$CFLAGS -DSQLITE_MAX_LENGTH=128000000 \
                -DSQLITE_DEBUG=1 \
                -DSQLITE_MAX_PAGE_COUNT=16384"
 
-"$TARGET/repo"/configure --disable-shared
+"$TARGET/repo"/configure --disable-shared --enable-rtree
 make clean
 make -j$(nproc)
 make sqlite3.c


### PR DESCRIPTION
Hi,

if _rtree_ is not enabled, CVE-2017-10989 (JCH225.patch) might not be reachable.

Stephan