### PR TITLE
Fix symcc lit install issues

### DIFF
--- a/fuzzers/symcc_afl/preinstall.sh
+++ b/fuzzers/symcc_afl/preinstall.sh
@@ -5,7 +5,7 @@ apt-get update && \
     apt-get install -y make build-essential clang-9 git wget cmake subversion \
         ninja-build python-pip zlib1g-dev rustc cargo inotify-tools
 
-pip install svn+https://llvm.org/svn/llvm-project/llvm/trunk/utils/lit
+pip install lit
 
 update-alternatives \
   --install /usr/lib/llvm              llvm             /usr/lib/llvm-9  20 \

--- a/fuzzers/symcc_analysis/preinstall.sh
+++ b/fuzzers/symcc_analysis/preinstall.sh
@@ -5,7 +5,7 @@ apt-get update && \
     apt-get install -y make build-essential clang-9 git wget cmake subversion \
         ninja-build python-pip zlib1g-dev rustc cargo inotify-tools
 
-pip install svn+https://llvm.org/svn/llvm-project/llvm/trunk/utils/lit
+pip install lit
 
 update-alternatives \
   --install /usr/lib/llvm              llvm             /usr/lib/llvm-9  20 \


### PR DESCRIPTION
Hello,

I found out that the current command for installing lit is returning 
```
Forbidden
You don't have permission to access /svn/llvm-project/llvm/trunk/utils/lit on this server.
```
See if the easier way is better, which is also currently used in the Dockerfile of symcc.