### PR TITLE
Fix to AFL++ crashes directory

### DIFF
--- a/fuzzers/aflplusplus/findings.sh
+++ b/fuzzers/aflplusplus/findings.sh
@@ -5,7 +5,7 @@
 # - env SHARED: path to directory shared with host (to store results)
 ##
 
-CRASH_DIR="$SHARED/findings/crashes"
+CRASH_DIR="$SHARED/findings/default/crashes"
 
 if [ ! -d "$CRASH_DIR" ]; then
     exit 1

--- a/fuzzers/aflplusplus_lto/findings.sh
+++ b/fuzzers/aflplusplus_lto/findings.sh
@@ -5,7 +5,7 @@
 # - env SHARED: path to directory shared with host (to store results)
 ##
 
-CRASH_DIR="$SHARED/findings/crashes"
+CRASH_DIR="$SHARED/findings/default/crashes"
 
 if [ ! -d "$CRASH_DIR" ]; then
     exit 1

--- a/fuzzers/aflplusplus_lto_asan/findings.sh
+++ b/fuzzers/aflplusplus_lto_asan/findings.sh
@@ -5,7 +5,7 @@
 # - env SHARED: path to directory shared with host (to store results)
 ##
 
-CRASH_DIR="$SHARED/findings/crashes"
+CRASH_DIR="$SHARED/findings/default/crashes"
 
 if [ ! -d "$CRASH_DIR" ]; then
     exit 1


### PR DESCRIPTION
With this change, running the `./post_extract.sh` script should be able to retrieve the bugs discovered by AFL++ after a fuzzing campaign

Should fix #127 