### PR TITLE
Compatibility fix across shells when running containers

### DIFF
--- a/magma/run.sh
+++ b/magma/run.sh
@@ -46,7 +46,7 @@ fi
 
 # launch the fuzzer in parallel with the monitor
 rm -f "$MONITOR/tmp"*
-polls=("$MONITOR"/*)
+polls=($(ls ${MONITOR}))
 if [ ${#polls[@]} -eq 0 ]; then
     counter=0
 else


### PR DESCRIPTION
Ref issue #132 

New PR to simplify rebase 

- Improves compatibility across shells
- $MONITOR variable previously wasn't expanded in certain versions of bash