### PR TITLE
Fix SSL015 CANARIES condition

### DIFF
--- a/targets/openssl/patches/bugs/SSL015.patch
+++ b/targets/openssl/patches/bugs/SSL015.patch
@@ -16,7 +16,7 @@ index 2cf62b62cd..f53a5e0082 100644
      }
 +#else
 +#ifdef MAGMA_ENABLE_CANARIES
-+    MAGMA_LOG("%MAGMA_BUG%", MAGMA_OR(p7 == NULL, p7->d.ptr));
++    MAGMA_LOG("%MAGMA_BUG%", MAGMA_OR(p7 == NULL, p7->d.ptr == NULL));
 +#endif
 +#endif
  
@@ -80,7 +80,7 @@ index 2cf62b62cd..f53a5e0082 100644
  
 +#else
 +#ifdef MAGMA_ENABLE_CANARIES
-+    MAGMA_LOG("%MAGMA_BUG%", MAGMA_OR(p7 == NULL, p7->d.ptr));
++    MAGMA_LOG("%MAGMA_BUG%", MAGMA_OR(p7 == NULL, p7->d.ptr == NULL));
 +#endif
 +#endif
      if (PKCS7_type_is_signed(p7)) {


### PR DESCRIPTION
According to the code in `MAGMA_ENABLE_FIXES` 
```C
if (p7->d.ptr == NULL) {
    PKCS7err(PKCS7_F_PKCS7_DATAINIT, PKCS7_R_NO_CONTENT);
    return NULL;
}
```
and other 2 CANARIES code, 
https://github.com/HexHive/magma/blob/75d1ae7b180443a778b8830c79176ca5f93642ac/targets/openssl/patches/bugs/SSL015.patch#L40
https://github.com/HexHive/magma/blob/75d1ae7b180443a778b8830c79176ca5f93642ac/targets/openssl/patches/bugs/SSL015.patch#L61
`p7->d.ptr` should also be null when vulnerability is triggered.
