### PR TITLE
fix: rename magma macro (dev branch)

### DIFF
--- a/targets/lua/patches/bugs/LUA004.patch
+++ b/targets/lua/patches/bugs/LUA004.patch
@@ -94,7 +94,7 @@ index c5e3b437..07524a8e 100644
    L->openupval = NULL;
    L->status = LUA_OK;
    L->errfunc = 0;
-+#ifdef ENABLE_MAGMA_FIXES
++#ifdef MAGMA_ENABLE_FIXES
    L->oldpc = 0;
 +#endif
  }


### PR DESCRIPTION
Renamed "ENABLE_MAGMA_FIXES" to "MAGMA_ENABLE_FIXES".